### PR TITLE
Add support for activity active states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to the "CobaltNext" extension will be documented in this
 file.
 
+## [0.1.6] - 2019-11-27
+
+### Changed
+* Updated the inactive and active states in the activity bar.
+
 ## [0.1.5] - 2019-##-##
 
 ### Changed

--- a/themes/CobaltNext.json
+++ b/themes/CobaltNext.json
@@ -7,8 +7,11 @@
     "activityBar.border": "#1b2b34",
     "activityBar.dropBackground": "#0b151b",
     "activityBar.foreground": "#d8dee9",
+    "activityBar.inactiveForeground": "#65737e",
     "activityBarBadge.background": "#fac863",
     "activityBarBadge.foreground": "#1b2b34",
+    "activityBar.activeBorder":  "#5fb3b3",
+    "activityBar.activeBackground": "#343d46",
     // badge
     "badge.background": "#343d46",
     "badge.foreground": "#d8dee9",


### PR DESCRIPTION
Updating the Activity bar to support active and inactive states.

Updates included:
• Set active border to Teal: `"activityBar.activeBorder":  "#5fb3b3",`
• Set active background to match active tabs:`"activityBar.activeBackground": "#343d46",`
• Set inactive foreground to match inactive tabs: `"activityBar.inactiveForeground": "#65737e",`

_before_
![image](https://user-images.githubusercontent.com/1840132/69728774-1a25be80-10f3-11ea-8c53-6768097b2057.png)

_after_
![image](https://user-images.githubusercontent.com/1840132/69728839-345f9c80-10f3-11ea-8fed-9d4a8ad5d042.png)
