### PR TITLE
Fix input selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to the "CobaltNext" extension will be documented in this
 file.
 
+## [0.2.3] - 2020-4-13
+
+### Changed
+* Updated the color of selections inside of inputs on the Dark Version.
+
 ## [0.2.2] - 2020-3-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "CobaltNext",
     "displayName": "Cobalt Next",
     "description": "If Oceanic Next and Cobalt2 made a baby in the form of a theme for VSCode.",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "dline",
     "engines": {
         "vscode": "^1.17.0"

--- a/themes/CobaltNext-Dark.json
+++ b/themes/CobaltNext-Dark.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cobalt Next",
+  "name": "Cobalt Next Dark",
   "type": "dark",
   "colors": {
     // activityBar

--- a/themes/CobaltNext-Dark.json
+++ b/themes/CobaltNext-Dark.json
@@ -216,7 +216,7 @@
     "scrollbarSlider.background": "#4f5b66aa",
     "scrollbarSlider.hoverBackground": "#343d46aa",
     // selection
-    "selection.background": "#0d3a58",
+    "selection.background": "#fac86344",
     // settings
     "settings.dropdownListBorder": "#5fb3b3",
     "settings.modifiedItemIndicator": "#5fb3b3",


### PR DESCRIPTION
In inputs, the selection on the Dark Version was too dark to see. This PR Updates and fixes that.

### Before
![image](https://user-images.githubusercontent.com/1840132/79164148-12b33900-7da6-11ea-8234-f19d72cb25b6.png)

### After
![image](https://user-images.githubusercontent.com/1840132/79164181-2199eb80-7da6-11ea-847b-ec845af4cbaf.png)