### PR TITLE
Clean Up Diff Styles

### DIFF
--- a/themes/CobaltNext-Dark.json
+++ b/themes/CobaltNext-Dark.json
@@ -30,10 +30,14 @@
     // description
     "descriptionForeground": "#d8dee9",
     // diff
-    "diffEditor.insertedTextBackground": "#99c79422",
-    "diffEditor.insertedTextBorder": "#99c794",
-    "diffEditor.removedTextBackground": "#ed6f7d22",
-    "diffEditor.removedTextBorder": "#ed6f7d",
+    "diffEditor.insertedTextBackground": "#99c79433",
+    "diffEditor.insertedTextBorder": "#99c79400",
+    "diffEditor.insertedLineBackground": "#223132",
+    "diffEditor.removedTextBackground": "#ed6f7d00",
+    "diffEditor.removedTextBorder": "#ed6f7d00",
+    "diffEditor.removedLineBackground": "#2E272F",
+    "diffEditorOverview.insertedForeground": "#99c79499",
+    "diffEditorOverview.removedForeground": "#ed6f7d99",
     // dropdown
     "dropdown.background": "#1b2b34",
     "dropdown.border": "#5fb3b3",

--- a/themes/CobaltNext-Minimal.json
+++ b/themes/CobaltNext-Minimal.json
@@ -31,12 +31,12 @@
     // description
     "descriptionForeground": "#d8dee9",
     // diff
-    "diffEditor.insertedTextBackground": "#99c79422",
+    "diffEditor.insertedTextBackground": "#99c79415",
     "diffEditor.insertedTextBorder": "#99c79400",
-    "diffEditor.insertedLineBackground": "#99c79411",
+    "diffEditor.insertedLineBackground": "#223132",
     "diffEditor.removedTextBackground": "#ed6f7d00",
     "diffEditor.removedTextBorder": "#ed6f7d00",
-    "diffEditor.removedLineBackground": "#ed6f7d22",
+    "diffEditor.removedLineBackground": "#2E272F",
     "diffEditorOverview.insertedForeground": "#99c79499",
     "diffEditorOverview.removedForeground": "#ed6f7d99",
     // dropdown

--- a/themes/CobaltNext-Minimal.json
+++ b/themes/CobaltNext-Minimal.json
@@ -32,9 +32,13 @@
     "descriptionForeground": "#d8dee9",
     // diff
     "diffEditor.insertedTextBackground": "#99c79422",
-    "diffEditor.insertedTextBorder": "#99c794",
-    "diffEditor.removedTextBackground": "#ed6f7d22",
-    "diffEditor.removedTextBorder": "#ed6f7d",
+    "diffEditor.insertedTextBorder": "#99c79400",
+    "diffEditor.insertedLineBackground": "#99c79411",
+    "diffEditor.removedTextBackground": "#ed6f7d00",
+    "diffEditor.removedTextBorder": "#ed6f7d00",
+    "diffEditor.removedLineBackground": "#ed6f7d22",
+    "diffEditorOverview.insertedForeground": "#99c79499",
+    "diffEditorOverview.removedForeground": "#ed6f7d99",
     // dropdown
     "dropdown.background": "#1b2b34",
     "dropdown.border": "#5fb3b3",
@@ -130,7 +134,9 @@
     "extensionButton.prominentHoverBackground": "#4e9b9bcc",
     "focusBorder": "#343d46",
     "foreground": "#d8dee9",
-    //git
+    //gitdiff
+    // Diffs
+    // super important
     "gitDecoration.modifiedResourceForeground": "#fac863",
     "gitDecoration.deletedResourceForeground": "#ed6f7d",
     "gitDecoration.untrackedResourceForeground": "#5fb3b3",

--- a/themes/CobaltNext.json
+++ b/themes/CobaltNext.json
@@ -30,10 +30,14 @@
     // description
     "descriptionForeground": "#d8dee9",
     // diff
-    "diffEditor.insertedTextBackground": "#99c79422",
-    "diffEditor.insertedTextBorder": "#99c794",
-    "diffEditor.removedTextBackground": "#ed6f7d22",
-    "diffEditor.removedTextBorder": "#ed6f7d",
+    "diffEditor.insertedTextBackground": "#99c79433",
+    "diffEditor.insertedTextBorder": "#99c79400",
+    "diffEditor.insertedLineBackground": "#223132",
+    "diffEditor.removedTextBackground": "#ed6f7d00",
+    "diffEditor.removedTextBorder": "#ed6f7d00",
+    "diffEditor.removedLineBackground": "#2E272F",
+    "diffEditorOverview.insertedForeground": "#99c79499",
+    "diffEditorOverview.removedForeground": "#ed6f7d99",
     // dropdown
     "dropdown.background": "#0b151b",
     "dropdown.border": "#5fb3b3",


### PR DESCRIPTION
As suggested in #33, this PR cleans up the diff styles by removing the border and perceived borders when using translucent colors.

## Before:
![image](https://user-images.githubusercontent.com/1840132/188256043-171a4090-fecd-4ab1-8b3d-f39e664c4956.png)

## After:
![image](https://user-images.githubusercontent.com/1840132/188256049-efd93455-1d00-428a-a3cd-14e82539c579.png)
